### PR TITLE
support js require ts progject

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ the transformer will fill in the `allThemes` variable so the file will be:
 import { Theme, createTheme } from '../Theme'
 
 const allThemes: { [name: string]: Theme } = {
-  dark: require('./dark').default,
-  magic: require('./magic').default,
-  'partial/light': require('./partial/light').default,
-  'partial/stars': require('./partial/stars').default,
+  dark: require('tslib').__importDefault(require('./dark')).default,
+  magic: require('tslib').__importDefault(require('./magic')).default,
+  'partial/light': require('tslib').__importDefault(require('./partial/light')).default,
+  'partial/stars': require('tslib').__importDefault(require('./partial/stars')).default,
 }
 
 Object.entries(allThemes).forEach(([name, theme]) => createTheme(name, theme))

--- a/__test__/plugins/parasite.ts
+++ b/__test__/plugins/parasite.ts
@@ -1,2 +1,3 @@
 const result: string = 'Hello from parasite.ts'
+module.exports = result
 export default result

--- a/src/RequireInserter.ts
+++ b/src/RequireInserter.ts
@@ -138,6 +138,18 @@ export default class RequireInserter implements NodeVisitor<VariableDeclaration>
             createStringLiteral(fileDefinition.filePath),
           ])
           if (fileDefinition.sourceCode) {
+            const tslibRequireExpresssion = createCallExpression(createIdentifier('require'), undefined, [
+              createStringLiteral('tslib'),
+            ])
+            const importDefaultExpression = createPropertyAccessExpression(
+              tslibRequireExpresssion,
+              createIdentifier('__importDefault')
+            )
+
+            requireExpression = createCallExpression(importDefaultExpression, undefined, [
+              requireExpression,
+            ])
+
             requireExpression = createPropertyAccessExpression(
               requireExpression,
               createIdentifier('default')


### PR DESCRIPTION
Hi
Here is our project
a.js
```
require('b')
```

b.ts

```
const name = 'b'
export default name;

// just for support js require
module.exports = name
```

so 
when I use this plugin and need includes b.ts
require('b').default will be undefined
so I need add tslib.__importDefault for support this case
